### PR TITLE
Support linting single RPM spec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM saltstack/centos-6-minimal
 MAINTAINER Sasha Gerrand <centos-rpms@sgerrand.com>
 ENV SPECSDIR /specs
+ENV SPECFILE=""
 RUN yum clean all \
   && yum update -y \
   && yum install -y rpmlint \

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ this mount point can be changed using the `SPECSDIR` environment variable.
 
 ## Environment
 
-There is currently one environment variable which can be changed at run time:
+There is currently two environment variables which can be changed at run time:
 
 * `SPECSDIR`: Defaults to `/specs`. This specifies the mount point for your
   specs directory. If overridden, this mount point must exist for the linter
   script to work.
+* `SPECFILE`: Defaults to an empty string. This specifies the location of a
+  single spec file. The file can exist within the `SPECSDIR` directory or a
+  separate location on the file system.

--- a/rpmlinter
+++ b/rpmlinter
@@ -1,8 +1,17 @@
 #!/bin/sh
 set -e
 
-! test -d $SPECSDIR \
+! test -d "$SPECSDIR" \
     && echo "Error: expected '$SPECSDIR' do be a directory" \
     && exit 1
 
-rpmlint "$SPECSDIR"
+lint_file_exists() {
+    test -f "$1" && rpmlint "$1"
+}
+
+if ! test -z "$SPECFILE"
+then
+    lint_file_exists "$SPECFILE" || lint_file_exists "$SPECSDIR/$SPECFILE"
+else
+    rpmlint "$SPECSDIR"
+fi


### PR DESCRIPTION
💁  These changes enable a single spec file to be linted by specifying the filesystem
location via a `SPECFILE` environment variable.